### PR TITLE
Added Java SE API methods to MidiMessage and SysexMessage

### DIFF
--- a/MIDIDriver/src/jp/kshoji/javax/sound/midi/MidiMessage.java
+++ b/MIDIDriver/src/jp/kshoji/javax/sound/midi/MidiMessage.java
@@ -63,4 +63,10 @@ public abstract class MidiMessage implements Cloneable {
 	public String toString() {
 		return getClass().getName() + ":" + toHexString(data);
 	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#clone()
+	 */
+	public abstract Object clone();
 }

--- a/MIDIDriver/src/jp/kshoji/javax/sound/midi/SysexMessage.java
+++ b/MIDIDriver/src/jp/kshoji/javax/sound/midi/SysexMessage.java
@@ -24,6 +24,16 @@ public class SysexMessage extends MidiMessage {
 
 	/*
 	 * (non-Javadoc)
+	 * @see #setMessage(byte[], int)
+	 */
+	public SysexMessage(byte[] data, int length)
+			throws InvalidMidiDataException {
+		super(null);
+		setMessage(data, length);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see jp.kshoji.javax.sound.midi.MidiMessage#setMessage(byte[], int)
 	 */
 	@Override


### PR DESCRIPTION
MidiMessage
----------------

Added abstract `clone` method to class, see (http://docs.oracle.com/javase/7/docs/api/javax/sound/midi/MidiMessage.html#clone%28%29)

This method lets us conveniently clone any MIDI message: 

```java
MidiMessage makeCopy(MidiMessage message) {
    if (message instanceof ShortMessage) {
        return (ShortMessage) message.clone();
    } else {
        return (MidiMessage) message.clone();
    }
}
```

SysexMessage
-------------------

Added constructor `public SysexMessage(byte[] data, int length)` class, see (http://docs.oracle.com/javase/7/docs/api/javax/sound/midi/SysexMessage.html#SysexMessage%28byte[],%20int%29)