### PR TITLE
Cache device info so it remains valid after disconnection

### DIFF
--- a/MIDIDriver/src/jp/kshoji/javax/sound/midi/usb/UsbMidiDevice.java
+++ b/MIDIDriver/src/jp/kshoji/javax/sound/midi/usb/UsbMidiDevice.java
@@ -32,6 +32,8 @@ public final class UsbMidiDevice implements MidiDevice {
 
 	private boolean isOpened;
 
+    private Info cachedInfo = null;
+
     /**
      * Constructor
      *
@@ -63,6 +65,8 @@ public final class UsbMidiDevice implements MidiDevice {
     @NonNull
 	@Override
 	public Info getDeviceInfo() {
+        if (cachedInfo != null)
+            return cachedInfo;
         UsbDevice usbDevice = null;
 
         for (final MidiInputDevice midiInputDevice : transmitters.keySet()) {
@@ -78,10 +82,10 @@ public final class UsbMidiDevice implements MidiDevice {
 
         if (usbDevice == null) {
             // XXX returns `null` information
-            return new Info("(null)", "(null)", "(null)", "(null)");
+            return cachedInfo = new Info("(null)", "(null)", "(null)", "(null)");
         }
 
-        return new Info(usbDevice.getDeviceName(), //
+        return cachedInfo = new Info(usbDevice.getDeviceName(), //
 				String.format("vendorId: %x, productId: %x", usbDevice.getVendorId(), usbDevice.getProductId()), //
 				"deviceId:" + usbDevice.getDeviceId(), //
 				usbDevice.getDeviceName());


### PR DESCRIPTION
Background: In the process of emitting an event when a device is detached, kshoji/javax.sound.midi-for-Android#10 invokes `getDeviceInfo()` on detached devices.
- In USB-MIDI-Driver 0.1.4 this results in a `NullPointerException` bubbling up from `getDeviceInfo()`'s use of a disposed USB device.
- On the current `develop` branch, [the `null` code path is guarded](https://github.com/kshoji/USB-MIDI-Driver/blob/0409a840477c42826f5b1959f3af8ca9c59ec592/MIDIDriver/src/jp/kshoji/javax/sound/midi/usb/UsbMidiDevice.java#L79), but the device can't really be identified from its `Info` at that point. (For example, I use `Info.hashCode()` as an index into my own list of MIDI device wrappers, and rely on the `MidiSystem` listeners to keep it in sync)

This PR simply caches the `Info` instance inside `UsbMidiDevice` on the first access. Note that this is _lazy_ initialization, which is enough for my use case, but if `getDeviceInfo()` is only ever called when the device is disconnected, it will still return `"(null)"`s instead of the real info - which may be surprising for some users.
