### PR TITLE
Increase timeout for reading from USB Device in bulkTransfer call.

### DIFF
--- a/MIDIDriver/src/jp/kshoji/driver/midi/device/MidiInputDevice.java
+++ b/MIDIDriver/src/jp/kshoji/driver/midi/device/MidiInputDevice.java
@@ -241,7 +241,7 @@ public final class MidiInputDevice {
 
             // Don't allocate instances in the loop, as much as possible.
             while (!stopFlag) {
-                length = deviceConnection.bulkTransfer(usbEndpoint, bulkReadBuffer, maxPacketSize, 10);
+                length = deviceConnection.bulkTransfer(usbEndpoint, bulkReadBuffer, maxPacketSize, 1000);
 
                 synchronized (suspendSignal) {
                     if (suspendFlag) {


### PR DESCRIPTION
Should fix MIDI events being dropped occasionally. (issue #61)