### PR TITLE
Fix missing MIDI messages, without causing freezing

### DIFF
--- a/MIDIDriver/src/jp/kshoji/driver/midi/device/MidiInputDevice.java
+++ b/MIDIDriver/src/jp/kshoji/driver/midi/device/MidiInputDevice.java
@@ -241,7 +241,13 @@ public final class MidiInputDevice {
 
             // Don't allocate instances in the loop, as much as possible.
             while (!stopFlag) {
-                length = deviceConnection.bulkTransfer(usbEndpoint, bulkReadBuffer, maxPacketSize, 10);
+
+                // Certain timeout values for this bulkTransfer method can cause different issues:
+                // timeout = 0 (infinite): causes freezes with React. See https://github.com/flowkey/NativePlayer/issues/419
+                // timeout = 10 (ms): causes some MIDI events to be dropped, probably because 10ms is sometimes not enough time to
+                //                    receive many MIDI events at once.
+                // timeout = 1000 (ms): apparently doesn't cause either of the two issues above
+                length = deviceConnection.bulkTransfer(usbEndpoint, bulkReadBuffer, maxPacketSize, 1000);
 
                 synchronized (suspendSignal) {
                     if (suspendFlag) {


### PR DESCRIPTION
Sets the USB `bulkTransfer` timeout value in `MidiInputDevice.java` to `1000`, which should fix the problem of some MIDI messages not being recognized when the timeout is `10`, and avoids the problem of React freezing when the timeout is `0` (infinite).

See https://github.com/flowkey/NativePlayer/issues/419