### PR TITLE
Fix android 14 crash

### DIFF
--- a/MIDIDriver/build.gradle
+++ b/MIDIDriver/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 12
@@ -53,6 +53,11 @@ android {
             withSourcesJar()
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    buildToolsVersion '30.0.3'
 }
 
 publishing {

--- a/MIDIDriverSample/build.gradle
+++ b/MIDIDriverSample/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 12
@@ -41,5 +41,9 @@ android {
         // by a similar customization.
         debug.setRoot('build-types/debug')
         release.setRoot('build-types/release')
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }


### PR DESCRIPTION
Using `PendingIntent.FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT` fixes following crash:

```
--------- beginning of crash
02-14 18:04:54.290 E/AndroidRuntime( 3110): FATAL EXCEPTION: MidiDeviceConnectionWatchThread
02-14 18:04:54.290 E/AndroidRuntime( 3110): Process: com.flowkey.testapp, PID: 3110
02-14 18:04:54.290 E/AndroidRuntime( 3110): java.lang.IllegalArgumentException: com.flowkey.testapp: Targeting U+ (version 34 and above) disallows creating or retrieving a PendingIntent with FLAG_MUTABLE, an implicit Intent within and without FLAG_NO_CREATE and FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT for security reasons. To retrieve an already existing PendingIntent, use FLAG_NO_CREATE, however, to create a new PendingIntent with an implicit Intent use FLAG_IMMUTABLE.
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.os.Parcel.createExceptionOrNull(Parcel.java:3061)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.os.Parcel.createException(Parcel.java:3041)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.os.Parcel.readException(Parcel.java:3024)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.os.Parcel.readException(Parcel.java:2966)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.app.IActivityManager$Stub$Proxy.getIntentSenderWithFeature(IActivityManager.java:6568)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.app.PendingIntent.getBroadcastAsUser(PendingIntent.java:735)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.app.PendingIntent.getBroadcast(PendingIntent.java:718)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at jp.kshoji.driver.midi.device.MidiDeviceConnectionWatcher$MidiDeviceConnectionWatchThread.run(MidiDeviceConnectionWatcher.java:274)
02-14 18:04:54.290 E/AndroidRuntime( 3110): Caused by: android.os.RemoteException: Remote stack trace:
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at com.android.server.am.ActivityManagerService.getIntentSenderWithFeatureAsApp(ActivityManagerService.java:5277)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at com.android.server.am.ActivityManagerService.getIntentSenderWithFeature(ActivityManagerService.java:5220)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.app.IActivityManager$Stub.onTransact(IActivityManager.java:3251)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:2720)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.os.Binder.execTransactInternal(Binder.java:1339)
02-14 18:04:54.290 E/AndroidRuntime( 3110): 
```


However we also need to use the `RECEIVER_EXPORTED` flag in order to fix a follow-up issue:
```
2024-02-15 13:49:37.438 23760-23932 AndroidRuntime          com.flowkey.testapp                  E  FATAL EXCEPTION: MidiDeviceConnectionWatchThread
                                                                                                    Process: com.flowkey.testapp, PID: 23760
                                                                                                    java.lang.SecurityException: com.flowkey.testapp: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts
                                                                                                    	at android.os.Parcel.createExceptionOrNull(Parcel.java:3057)
                                                                                                    	at android.os.Parcel.createException(Parcel.java:3041)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:3024)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:2966)
                                                                                                    	at android.app.IActivityManager$Stub$Proxy.registerReceiverWithFeature(IActivityManager.java:5684)
                                                                                                    	at android.app.ContextImpl.registerReceiverInternal(ContextImpl.java:1852)
                                                                                                    	at android.app.ContextImpl.registerReceiver(ContextImpl.java:1792)
                                                                                                    	at android.app.ContextImpl.registerReceiver(ContextImpl.java:1780)
                                                                                                    	at android.content.ContextWrapper.registerReceiver(ContextWrapper.java:755)
                                                                                                    	at jp.kshoji.driver.midi.device.MidiDeviceConnectionWatcher$MidiDeviceConnectionWatchThread.run(MidiDeviceConnectionWatcher.java:287)
                                                                                                    Caused by: android.os.RemoteException: Remote stack trace:
                                                                                                    	at com.android.server.am.ActivityManagerService.registerReceiverWithFeature(ActivityManagerService.java:13927)
                                                                                                    	at android.app.IActivityManager$Stub.onTransact(IActivityManager.java:2570)
                                                                                                    	at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:2720)
                                                                                                    	at android.os.Binder.execTransactInternal(Binder.java:1339)
                                                                                                    	at android.os.Binder.execTransact(Binder.java:1275)
```