### PR TITLE
Make intent explicit and use RECEIVER_NOT_EXPORTED flag

### DIFF
--- a/MIDIDriver/build.gradle
+++ b/MIDIDriver/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 12
@@ -53,6 +53,7 @@ android {
             withSourcesJar()
         }
     }
+
 }
 
 publishing {

--- a/MIDIDriverSample/build.gradle
+++ b/MIDIDriverSample/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 12


### PR DESCRIPTION
With compileSdkVersion set to 34, we were experiencing a crash as soon as MIDI device got connected:

```
--------- beginning of crash
02-14 18:04:54.290 E/AndroidRuntime( 3110): FATAL EXCEPTION: MidiDeviceConnectionWatchThread
02-14 18:04:54.290 E/AndroidRuntime( 3110): Process: com.flowkey.testapp, PID: 3110
02-14 18:04:54.290 E/AndroidRuntime( 3110): java.lang.IllegalArgumentException: com.flowkey.testapp: Targeting U+ (version 34 and above) disallows creating or retrieving a PendingIntent with FLAG_MUTABLE, an implicit Intent within and without FLAG_NO_CREATE and FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT for security reasons. To retrieve an already existing PendingIntent, use FLAG_NO_CREATE, however, to create a new PendingIntent with an implicit Intent use FLAG_IMMUTABLE.
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.os.Parcel.createExceptionOrNull(Parcel.java:3061)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.os.Parcel.createException(Parcel.java:3041)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.os.Parcel.readException(Parcel.java:3024)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.os.Parcel.readException(Parcel.java:2966)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.app.IActivityManager$Stub$Proxy.getIntentSenderWithFeature(IActivityManager.java:6568)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.app.PendingIntent.getBroadcastAsUser(PendingIntent.java:735)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.app.PendingIntent.getBroadcast(PendingIntent.java:718)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at jp.kshoji.driver.midi.device.MidiDeviceConnectionWatcher$MidiDeviceConnectionWatchThread.run(MidiDeviceConnectionWatcher.java:274)
02-14 18:04:54.290 E/AndroidRuntime( 3110): Caused by: android.os.RemoteException: Remote stack trace:
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at com.android.server.am.ActivityManagerService.getIntentSenderWithFeatureAsApp(ActivityManagerService.java:5277)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at com.android.server.am.ActivityManagerService.getIntentSenderWithFeature(ActivityManagerService.java:5220)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.app.IActivityManager$Stub.onTransact(IActivityManager.java:3251)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:2720)
02-14 18:04:54.290 E/AndroidRuntime( 3110):     at android.os.Binder.execTransactInternal(Binder.java:1339)
02-14 18:04:54.290 E/AndroidRuntime( 3110): 
```

This PR fixes this by making the intent explicit and using the `RECEIVER_NOT_EXPORTED` flag (for security reasons).